### PR TITLE
Update qunit-notifications dependency version.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,6 @@
     "tests"
   ],
   "dependencies": {
-    "qunit-notifications": "~0.0.6"
+    "qunit-notifications": "~0.1.0"
   }
 }


### PR DESCRIPTION
I'm being presumptive and opening a PR to ember-cli with 0.1.0 as the next version of ember-qunit-notifications.